### PR TITLE
Fix response type validation for newer Wiz light models

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,10 +52,10 @@ export const getPilotResponseTemplate = makeTypeTemplate({
 	result: {
 		mac: ["string", true],
 		rssi: ["number", true],
-		src: ["string", true],
 		state: ["boolean", true],
 		sceneId: ["number", true],
 		// optional properties
+		src: ["string", false],
 		temp: ["number", false],
 		speed: ["number", false],
 		r: ["number", false],
@@ -90,7 +90,7 @@ export const syncPilotResponseTemplate = makeTypeTemplate({
 	params: {
 		mac: ["string", true],
 		rssi: ["number", true],
-		src: ["string", true],
+		src: ["string", false],
 		mqttCd: ["number", false],
 		ts: ["number", false],
 		...pilotTemplate,


### PR DESCRIPTION
@uditkarode
This pull request fixes compatibility with newer Wiz light models. I have some older and newer WiZ lights, and I noticed this package was only working on my older models. Newer models no longer include the src property in the response, causing type validation to fail. I've made the src property optional in the pilot response types to ensure compatibility across both old and new models. I've tested and verified compatibility with both my models using the discover method and manual bulb IP configuration. 

Please review and let me know if you have any questions, or if it's good to merge. It would also be great if you could update the package on npm with this fix because I would love to use it for a project I'm working on. Thank you :)